### PR TITLE
Spark

### DIFF
--- a/src/main/java/Core/Job.java
+++ b/src/main/java/Core/Job.java
@@ -105,6 +105,10 @@ public class Job {
         }
     }
 
+    public CommandBuilder getCmdBuilder() {
+        return cmdBuilder;
+    }
+
     public String getCommand() {
         return cmdBuilder.getCommand(runnerArguments, jarFile, jarArguments);
     }

--- a/src/main/java/Core/Job.java
+++ b/src/main/java/Core/Job.java
@@ -1,7 +1,7 @@
 package Core;
 
 import Core.commandBuilder.CommandBuilder;
-import util.Tuple3;
+import util.Argument;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -15,8 +15,8 @@ import java.util.ArrayList;
 public class Job {
 
     private String jarFile;
-    private ArrayList<Tuple3> runnerArguments;
-    private ArrayList<Tuple3> jarArguments;
+    private ArrayList<Argument> runnerArguments;
+    private ArrayList<Argument> jarArguments;
     private CommandBuilder cmdBuilder;
     private String runner;
     private String jobName;
@@ -27,7 +27,7 @@ public class Job {
 
     /* Constructors */
 
-    public Job(String jarFile, ArrayList<Tuple3> runnerArguments, ArrayList<Tuple3> jarArguments, CommandBuilder cmdBuilder,
+    public Job(String jarFile, ArrayList<Argument> runnerArguments, ArrayList<Argument> jarArguments, CommandBuilder cmdBuilder,
                String runner, String jobName, Integer duplicateNumber, Long delay, String experimentName) {
         this.jarFile = jarFile;
         this.runnerArguments = runnerArguments;
@@ -109,15 +109,15 @@ public class Job {
         return cmdBuilder.getCommand(runnerArguments, jarFile, jarArguments);
     }
 
-    private void setArgument(String value, ArrayList<Tuple3> arguments) {
+    private void setArgument(String value, ArrayList<Argument> arguments) {
         setArgument("", value, arguments);
     }
 
-    private void setArgument(String key, String value, ArrayList<Tuple3> arguments) {
+    private void setArgument(String key, String value, ArrayList<Argument> arguments) {
         if (key.isEmpty()) {
-            arguments.add(new Tuple3(key, "", value));
+            arguments.add(new Argument(key, value));
         } else {
-            for (Tuple3 tuple : arguments) {
+            for (Argument tuple : arguments) {
                 if (tuple.getKey().equalsIgnoreCase(key)) {
                     tuple.setValue(value);
                 }
@@ -125,16 +125,16 @@ public class Job {
         }
     }
 
-    private void setOrOverwriteArguments(ArrayList<Tuple3> arguments, ArrayList<Tuple3> newArguments) {
+    private void setOrOverwriteArguments(ArrayList<Argument> arguments, ArrayList<Argument> newArguments) {
         if (arguments.isEmpty()) {
             arguments.addAll(newArguments);
         } else {
-            ArrayList<Tuple3> argumentsToAdd = new ArrayList<>();
-            for (Tuple3 newTuple: newArguments) {
+            ArrayList<Argument> argumentsToAdd = new ArrayList<>();
+            for (Argument newTuple: newArguments) {
                 if (newTuple.getKey().isEmpty()) {
                     arguments.add(newTuple);
                 } else {
-                    for (Tuple3 tuple: arguments) {
+                    for (Argument tuple: arguments) {
                         if (tuple.getKey().equalsIgnoreCase(newTuple.getKey())) {
                             tuple.setValue(newTuple.getValue());
                         }
@@ -154,15 +154,15 @@ public class Job {
         setArgument(key, value, runnerArguments);
     }
 
-    public void setRunnerArguments(ArrayList<Tuple3> runnerArguments) {
+    public void setRunnerArguments(ArrayList<Argument> runnerArguments) {
         this.runnerArguments = runnerArguments;
     }
 
-    public void setOrOverwriteRunnerArguments(ArrayList<Tuple3> newArguments) {
+    public void setOrOverwriteRunnerArguments(ArrayList<Argument> newArguments) {
         setOrOverwriteArguments(runnerArguments, newArguments);
     }
 
-    public ArrayList<Tuple3> getRunnerArguments() {
+    public ArrayList<Argument> getRunnerArguments() {
         return runnerArguments;
     }
 
@@ -176,15 +176,15 @@ public class Job {
         setArgument(key, value, jarArguments);
     }
 
-    public void setJarArguments(ArrayList<Tuple3> jarArguments) {
+    public void setJarArguments(ArrayList<Argument> jarArguments) {
         this.jarArguments = jarArguments;
     }
 
-    public void setOrOverwriteJarArguments(ArrayList<Tuple3> newArguments) {
+    public void setOrOverwriteJarArguments(ArrayList<Argument> newArguments) {
         setOrOverwriteArguments(jarArguments, newArguments);
     }
 
-    public ArrayList<Tuple3> getJarArguments() {
+    public ArrayList<Argument> getJarArguments() {
         return jarArguments;
     }
 
@@ -218,5 +218,9 @@ public class Job {
 
     public void setJobName(String jobName) {
         this.jobName = jobName;
+    }
+
+    public String getRunnerArgumentPrefix() {
+        return cmdBuilder.getRunnerPrefix();
     }
 }

--- a/src/main/java/Core/commandBuilder/CommandBuilder.java
+++ b/src/main/java/Core/commandBuilder/CommandBuilder.java
@@ -1,5 +1,5 @@
 package Core.commandBuilder;
-`
+
 import util.Argument;
 import java.util.ArrayList;
 
@@ -7,18 +7,13 @@ import java.util.ArrayList;
  * Created by joh-mue on 23/02/16.
  */
 public abstract class CommandBuilder {
-    String startLine;
-    String stopLine;
-    String submittedLine;
-    String runnerPrefix;
-
     public static CommandBuilder getCommandBuilder(String runner) throws Exception {
-        // TODO: this is static, actually pick the CommandBuilder
         switch (runner) {
             case "flink": return new FlinkCommandBuilder();
             case "spark": return new SparkCommandBuilder();
         default:
-            throw new Exception("There is no CommandBuilder for the runner " + runner);
+            throw new Exception("There is no CommandBuilder defined for the runner " + runner + ". Check the runner spelling " +
+                    "in your job definition.");
         }
     }
 
@@ -31,7 +26,7 @@ public abstract class CommandBuilder {
     protected String concatRunnerArguments(ArrayList<Argument> arguments) {
         String finalString = " ";
         for (Argument argument : arguments) {
-            finalString += runnerPrefix + argument + " ";
+            finalString += getRunnerPrefix() + argument + " ";
         }
         return finalString;
     }
@@ -44,9 +39,10 @@ public abstract class CommandBuilder {
         return finalString;
     }
 
+    public abstract String getCommand(ArrayList<Argument> runnerArguments, String jarFile, ArrayList<Argument> jarArguments);
+
     public abstract String getStartLine();
     public abstract String getStopLine();
     public abstract String getSubmittedLine();
     public abstract String getRunnerPrefix();
-    public abstract String getCommand(ArrayList<Argument> runnerArguments, String jarFile, ArrayList<Argument> jarArguments);
 }

--- a/src/main/java/Core/commandBuilder/CommandBuilder.java
+++ b/src/main/java/Core/commandBuilder/CommandBuilder.java
@@ -1,21 +1,52 @@
 package Core.commandBuilder;
-
-import akka.io.Dns;
-import util.Tuple3;
-
+`
+import util.Argument;
 import java.util.ArrayList;
 
 /**
  * Created by joh-mue on 23/02/16.
  */
-public interface CommandBuilder {
-    String getCommand(ArrayList<Tuple3> runnerArguments, String jarFile, ArrayList<Tuple3> jarArguments);
+public abstract class CommandBuilder {
+    String startLine;
+    String stopLine;
+    String submittedLine;
+    String runnerPrefix;
 
-    static CommandBuilder getCommandBuilder(String runner) throws Exception {
+    public static CommandBuilder getCommandBuilder(String runner) throws Exception {
         // TODO: this is static, actually pick the CommandBuilder
-        if (false) {
+        switch (runner) {
+            case "flink": return new FlinkCommandBuilder();
+            case "spark": return new SparkCommandBuilder();
+        default:
             throw new Exception("There is no CommandBuilder for the runner " + runner);
         }
-        return new FlinkCommandBuilder();
     }
+
+    /**
+     * Concats the arguments and returns them as one string.
+     * The String that will be returned starts and ends with a whitespace (" ")
+     * @param arguments
+     * @return String starting and ending with whitespace
+     */
+    protected String concatRunnerArguments(ArrayList<Argument> arguments) {
+        String finalString = " ";
+        for (Argument argument : arguments) {
+            finalString += runnerPrefix + argument + " ";
+        }
+        return finalString;
+    }
+
+    protected String concatJarArguments(ArrayList<Argument> arguments) {
+        String finalString = " ";
+        for (Argument argument : arguments) {
+            finalString += argument + " ";
+        }
+        return finalString;
+    }
+
+    public abstract String getStartLine();
+    public abstract String getStopLine();
+    public abstract String getSubmittedLine();
+    public abstract String getRunnerPrefix();
+    public abstract String getCommand(ArrayList<Argument> runnerArguments, String jarFile, ArrayList<Argument> jarArguments);
 }

--- a/src/main/java/Core/commandBuilder/FlinkCommandBuilder.java
+++ b/src/main/java/Core/commandBuilder/FlinkCommandBuilder.java
@@ -1,31 +1,43 @@
 package Core.commandBuilder;
 
 import util.Config;
-import util.Tuple3;
+import util.Argument;
 
 import java.util.ArrayList;
 
 /**
  * Created by Johannes on 08/02/16.
  */
-public class FlinkCommandBuilder implements CommandBuilder {
+public class FlinkCommandBuilder extends CommandBuilder {
 
     @Override
-    public String getCommand(ArrayList<Tuple3> runnerArguments, String jarFile, ArrayList<Tuple3> jarArguments) {
+    public String getCommand(ArrayList<Argument> runnerArguments, String jarFile, ArrayList<Argument> jarArguments) {
         String flinkHome = Config.getInstance().getConfigItem("flink-home-dir");
 
         if (jarFile.charAt(0) == '.') { // if the jarfile is relative (start with '.') it will be relative to flinkhome
             jarFile = flinkHome + "/" + jarFile.substring(1);
         }
 
-        return flinkHome + "/bin/flink run " + concatArguments(runnerArguments) + jarFile + concatArguments(jarArguments);
+        return flinkHome + "/bin/flink run " + concatRunnerArguments(runnerArguments) + jarFile + concatJarArguments(jarArguments);
     }
 
-    public String concatArguments(ArrayList<Tuple3> arguments) {
-        String finalString = " ";
-        for (Tuple3 argument : arguments) {
-            finalString += argument + " ";
-        }
-        return finalString;
+    @Override
+    public String getStartLine() {
+        return "All TaskManagers are connected";
+    }
+
+    @Override
+    public String getStopLine() {
+        return "The following messages were created by the YARN cluster while running the Job:";
+    }
+
+    @Override
+    public String getSubmittedLine() {
+        return "Submitted application";
+    }
+
+    @Override
+    public String getRunnerPrefix() {
+        return "-";
     }
 }

--- a/src/main/java/Core/commandBuilder/FlinkCommandBuilder.java
+++ b/src/main/java/Core/commandBuilder/FlinkCommandBuilder.java
@@ -12,7 +12,7 @@ public class FlinkCommandBuilder extends CommandBuilder {
 
     @Override
     public String getCommand(ArrayList<Argument> runnerArguments, String jarFile, ArrayList<Argument> jarArguments) {
-        String flinkHome = Config.getInstance().getConfigItem("flink-home-dir");
+        String flinkHome = Config.getInstance().getFlinkHome();
 
         if (jarFile.charAt(0) == '.') { // if the jarfile is relative (start with '.') it will be relative to flinkhome
             jarFile = flinkHome + "/" + jarFile.substring(1);

--- a/src/main/java/Core/commandBuilder/SparkCommandBuilder.java
+++ b/src/main/java/Core/commandBuilder/SparkCommandBuilder.java
@@ -1,15 +1,39 @@
 package Core.commandBuilder;
 
-import util.Tuple3;
+import util.Config;
+import util.Argument;
 
 import java.util.ArrayList;
 
 /**
  * Created by joh-mue on 10/05/16.
  */
-public class SparkCommandBuilder implements CommandBuilder {
+public class SparkCommandBuilder extends CommandBuilder {
     @Override
-    public String getCommand(ArrayList<Tuple3> runnerArguments, String jarFile, ArrayList<Tuple3> jarArguments) {
+    public String getCommand(ArrayList<Argument> runnerArguments, String jarFile, ArrayList<Argument> jarArguments) {
+        String sparkHome = Config.getInstance().getConfigItem("spark-home-dir");
+
+        String command = sparkHome + "/bin/spark-submit" + "--master yarn --deploy-mode cluster" + concatRunnerArguments(runnerArguments) + jarFile + concatJarArguments(jarArguments);
         return null;
+    }
+
+    @Override
+    public String getStartLine() {
+        return null;
+    }
+
+    @Override
+    public String getStopLine() {
+        return null;
+    }
+
+    @Override
+    public String getSubmittedLine() {
+        return null;
+    }
+
+    @Override
+    public String getRunnerPrefix() {
+        return "--";
     }
 }

--- a/src/main/java/Core/commandBuilder/SparkCommandBuilder.java
+++ b/src/main/java/Core/commandBuilder/SparkCommandBuilder.java
@@ -1,5 +1,6 @@
 package Core.commandBuilder;
 
+import com.sun.javaws.exceptions.MissingFieldException;
 import util.Config;
 import util.Argument;
 
@@ -11,25 +12,30 @@ import java.util.ArrayList;
 public class SparkCommandBuilder extends CommandBuilder {
     @Override
     public String getCommand(ArrayList<Argument> runnerArguments, String jarFile, ArrayList<Argument> jarArguments) {
-        String sparkHome = Config.getInstance().getConfigItem("spark-home-dir");
+        String sparkHome = Config.getInstance().getSparkHome();
 
-        String command = sparkHome + "/bin/spark-submit" + "--master yarn --deploy-mode cluster" + concatRunnerArguments(runnerArguments) + jarFile + concatJarArguments(jarArguments);
-        return null;
+        if (jarFile.charAt(0) == '.') { // if the jarfile is relative (start with '.') it will be relative to flinkhome
+            jarFile = sparkHome + "/" + jarFile.substring(1);
+        }
+
+        return sparkHome + "/bin/spark-submit "
+                + "--master yarn --deploy-mode cluster" + concatRunnerArguments(runnerArguments)
+                + jarFile + concatJarArguments(jarArguments);
     }
 
     @Override
     public String getStartLine() {
-        return null;
+        return "not yet set";
     }
 
     @Override
     public String getStopLine() {
-        return null;
+        return "not yet set";
     }
 
     @Override
     public String getSubmittedLine() {
-        return null;
+        return "not yet set";
     }
 
     @Override

--- a/src/main/java/parser/JobParser.java
+++ b/src/main/java/parser/JobParser.java
@@ -4,7 +4,7 @@ package parser;
 import Core.Job;
 import org.apache.log4j.Logger;
 import org.w3c.dom.*;
-import util.Tuple3;
+import util.Argument;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -38,6 +38,7 @@ public class JobParser {
 
             // per Job
             for (Element jobElement : jobs) {
+                // TODO: use JobFactory and Contructor only, no setting here
                 Job job = new Job();
 
                 job.setJobName(jobElement.getAttribute("name"));
@@ -68,7 +69,8 @@ public class JobParser {
                     break;
                 case "arguments":
 //                    job.setRunnerArguments(getArguments(item , "-"));
-                    job.setOrOverwriteRunnerArguments(getArguments(item, "-"));
+                    job.setOrOverwriteRunnerArguments(getArguments(item));
+                    // TODO: don't always set the prefix, just add it in concatArguements
                     break;
             }
 
@@ -86,14 +88,14 @@ public class JobParser {
                     break;
                 case "arguments":
 //                    job.setJarArguments(getArguments(item, ""));
-                    job.setOrOverwriteJarArguments(getArguments(item, ""));
+                    job.setOrOverwriteJarArguments(getArguments(item));
                     break;
             }
         }
     }
 
-    private static ArrayList<Tuple3> getArguments(Node node, String prefix) {
-        ArrayList<Tuple3> argumentList = new ArrayList<>();
+    private static ArrayList<Argument> getArguments(Node node) {
+        ArrayList<Argument> argumentList = new ArrayList<>();
 
         NodeList arguments = node.getChildNodes();
         for (int i = 0; i < arguments.getLength(); i++) {
@@ -104,7 +106,7 @@ public class JobParser {
                 if (attributes.getLength() != 0) {
                     parameterName = argument.getAttributes().item(0).getNodeValue();
                 }
-                argumentList.add(new Tuple3(parameterName, prefix, argument.getTextContent()));
+                argumentList.add(new Argument(parameterName, argument.getTextContent()));
             }
         }
         return argumentList;

--- a/src/main/java/parser/ScheduleParser.java
+++ b/src/main/java/parser/ScheduleParser.java
@@ -69,7 +69,7 @@ public class ScheduleParser {
 
         Job job;
         String textContent = jobNode.getTextContent();
-        if (jobNode.getTextContent().isEmpty() || jobNode.getTextContent().startsWith("\n")) { // no value defaults to 0
+        if (textContent.isEmpty() || textContent.startsWith("\n")) { // no value defaults to 0
             Long delay = new Long(0);
 
             Node delayNode = ((Element) jobNode).getElementsByTagName("delay").item(0);

--- a/src/main/java/util/Argument.java
+++ b/src/main/java/util/Argument.java
@@ -3,14 +3,12 @@ package util;
 /**
  * Created by joh-mue on 22/04/16.
  */
-public class Tuple3 {
+public class Argument {
     private String key;
-    private String prefix;
     private String value;
 
-    public Tuple3(String key, String prefix, String value) {
+    public Argument(String key, String value) {
         this.key = key;
-        this.prefix = prefix;
         this.value = value;
     }
 
@@ -28,7 +26,7 @@ public class Tuple3 {
 
     @Override
     public String toString() {
-        return prefix + key + " " + value;
+        return key + " " + value;
 
     }
 }

--- a/src/main/java/util/Config.java
+++ b/src/main/java/util/Config.java
@@ -1,5 +1,6 @@
 package util;
 
+import com.sun.javaws.exceptions.MissingFieldException;
 import parser.ConfigParser;
 
 import java.io.File;
@@ -13,8 +14,9 @@ public class Config {
     private static Config instance;
     private HashMap<String,String> itemHash;
 
-    public static final String HADOOP_CONF_DIR= "hadoop-conf-dir";
-    public static final String FLINK_HOME= "flink-home-dir";
+    public static final String HADOOP_CONF_DIR = "hadoop-conf-dir";
+    public static final String FLINK_HOME = "flink-home-dir";
+    public static final String SPARK_HOME = "spark-home-dir";
     public static final String LOG_DIR = "log-dir";
     public static final String OVERWRITE_LOGS= "overwriteLogs";
 
@@ -61,10 +63,10 @@ public class Config {
     public String getConfigItem(String key) {
         String configItem = itemHash.get(key);
         if (configItem == null) {
-            throw new NoSuchElementException("The item " + key + " was not set in your configuration file ().");
-        } else {
-            return configItem;
+            System.out.println("The item " + key + " was not set in your configuration file.");
+            System.exit(0);
         }
+        return configItem;
     }
 
     /**
@@ -81,6 +83,10 @@ public class Config {
     public static File getLogDir(String experimentName) {
         // TODO: [009b]should not call getInstance but be static instead
         String baseLogDir = Config.getInstance().getConfigItem(LOG_DIR);
+        if (baseLogDir.isEmpty()) {
+            System.out.println("You did not set " + LOG_DIR + " in your configuration file.");
+            System.exit(0);
+        }
         return new File(baseLogDir + '/' + experimentName);
     }
 
@@ -88,8 +94,32 @@ public class Config {
             return getConfigItem(HADOOP_CONF_DIR);
     }
 
+    /**
+     * If flink-home-dir is not set the program terminates.
+     *
+     * @return
+     */
     public String getFlinkHome() {
-        return getConfigItem(FLINK_HOME);
+        String flinkHome = getConfigItem(FLINK_HOME);
+        if (flinkHome.isEmpty()) {
+            System.out.println("You did not set " + FLINK_HOME + " in your configuration file.");
+            System.exit(0);
+        }
+        return flinkHome;
+    }
+
+    /**
+     * If spark-home-dir is not set the program terminates.
+     *
+     * @return
+     */
+    public String getSparkHome() {
+        String sparkHome = getConfigItem(SPARK_HOME);
+        if (sparkHome.isEmpty()) {
+            System.out.println("You did not set " + SPARK_HOME + " in your configuration file.");
+            System.exit(0);
+        }
+        return sparkHome;
     }
 
     /**

--- a/src/main/resources/config.xml
+++ b/src/main/resources/config.xml
@@ -3,13 +3,13 @@
 <config>
     <!-- general configuration -->
         <!-- to set the HADOOP_CONF_DIR environment variable -->
-        <hadoop-conf-directory>/path/to/hadoop-2.7.1/etc/hadoop/</hadoop-conf-directory>
+        <hadoop-conf-dir>/path/to/hadoop-2.7.1/etc/hadoop/</hadoop-conf-dir>
 
         <!-- directory where your flink instance resides -->
         <flink-home-dir>/path/to/flink-0.10.1/</flink-home-dir>
 
         <!-- directory where your spark instance resides -->
-        <spark-home-dir>/path/to/flink-0.10.1/</spark-home-dir>
+        <spark-home-dir>/path/to/spark-16.1-bin-hadoop2.6/</spark-home-dir>
 
         <!-- this is where logs will be saved to -->
         <log-dir>/path/to/logs/</log-dir>

--- a/src/main/resources/config.xml
+++ b/src/main/resources/config.xml
@@ -27,4 +27,5 @@
         <freamonMasterPort>1235</freamonMasterPort>
         <freamonMasterSystemName>masterSystem</freamonMasterSystemName>
         <freamonMasterActorName>monitorMaster</freamonMasterActorName>
+
 </config>

--- a/src/main/resources/jobs.xml
+++ b/src/main/resources/jobs.xml
@@ -44,4 +44,23 @@
             </arguments>
         </jar>
     </job>
+
+    <job name="sparkpi">
+        <runner>
+            <name>spark</name>
+            <arguments>
+                <argument name="class">org.apache.spark.examples.SparkPi</argument>
+                <!--<argument name="driver-memory">1g</argument>-->
+                <!--<argument name="executor-memory">512m</argument>-->
+                <!--<argument name="executor-cores">1</argument>-->
+                <!--<argument name="queue">thequeue</argument>-->
+            </arguments>
+        </runner>
+        <jar>
+            <path>./lib/spark-examples-1.6.1-hadoop2.6.0.jar</path>
+            <arguments>
+                <argument>10</argument>
+            </arguments>
+        </jar>
+    </job>
 </jobs>


### PR DESCRIPTION
fixed hadoop-conf-dir naming
spark-home-dir example
CommandBuilder.java is an abstract class instead of an interface
SparkCommandBuilder.java
console output is analyzed with respect to jobrunner
less exception are thrown, instead Conig.java exits gracefully if sth is wrong with the config.xml
added spark example to jobs.xml